### PR TITLE
Add output table to models.py

### DIFF
--- a/models.py
+++ b/models.py
@@ -44,7 +44,7 @@ class Meeting(models.Model):
     transcription_blob = models.CharField(max_length=256, blank=True, null=True)
     participants = models.ManyToManyField(User, related_name='participants', blank=True)
     meeting_recordings = models.ManyToManyField(MeetingRecordings, related_name='meeting_recordings', blank=True)
-    json_blob = models.CharField(max_length=256, blank=False, null=False)
+    feedback_blob = models.CharField(max_length=256, blank=True, null=True)
 
     class Meta:
         db_table = 'meetings'

--- a/models.py
+++ b/models.py
@@ -47,3 +47,15 @@ class Meeting(models.Model):
 
     class Meta:
         db_table = 'meetings'
+
+
+class Output(models.Model):
+    output = models.CharField(max_length=128, unique=True, primary_key=True)  # UUID of the output
+    meeting_date = models.DateTimeField(auto_now_add=True)
+    student_id = models.CharField(max_length=128, unique=False, blank=False, null=False)
+    teacher_id = models.CharField(max_length=128, unique=False, blank=False, null=False)
+    json_blob = models.CharField(max_length=256, blank=False, null=False)
+
+    class Meta:
+        #unique_together = ['output', 'student_id', 'teacher_id']
+        db_table = 'output'

--- a/models.py
+++ b/models.py
@@ -44,15 +44,7 @@ class Meeting(models.Model):
     transcription_blob = models.CharField(max_length=256, blank=True, null=True)
     participants = models.ManyToManyField(User, related_name='participants', blank=True)
     meeting_recordings = models.ManyToManyField(MeetingRecordings, related_name='meeting_recordings', blank=True)
-
-    class Meta:
-        db_table = 'meetings'
-
-
-class Output(models.Model):
-    meeting_uuid = models.CharField(max_length=128, unique=True, primary_key=True)  # UUID of the output
-    created_at = models.DateTimeField(auto_now_add=True)
     json_blob = models.CharField(max_length=256, blank=False, null=False)
 
     class Meta:
-        db_table = 'output'
+        db_table = 'meetings'

--- a/models.py
+++ b/models.py
@@ -50,12 +50,9 @@ class Meeting(models.Model):
 
 
 class Output(models.Model):
-    output = models.CharField(max_length=128, unique=True, primary_key=True)  # UUID of the output
-    meeting_date = models.DateTimeField(auto_now_add=True)
-    student_id = models.CharField(max_length=128, unique=False, blank=False, null=False)
-    teacher_id = models.CharField(max_length=128, unique=False, blank=False, null=False)
+    meeting_uuid = models.CharField(max_length=128, unique=True, primary_key=True)  # UUID of the output
+    created_at = models.DateTimeField(auto_now_add=True)
     json_blob = models.CharField(max_length=256, blank=False, null=False)
 
     class Meta:
-        #unique_together = ['output', 'student_id', 'teacher_id']
         db_table = 'output'


### PR DESCRIPTION
This model will hold the blob file name of the output jsons generated. Minimal fields required since we can use the meeting_uuid to access language and participant information.