### PR TITLE
Update serializers.py to specify the required fields upon initial login

### DIFF
--- a/serializers.py
+++ b/serializers.py
@@ -30,6 +30,16 @@ class UserSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             'email': {'required': True},
             'hashed_password': {'required': True},
+            'is_teacher': {'required': True},
+            'native_language': {'required': True},
+            'target_language': {'required': True},
+
+            'full_name': {'required': False},
+            'zoom_access_token': {'required': False},
+            'zoom_refresh_token': {'required': False},
+            'zoom_token_expiration': {'required': False},
+            'zoom_user_id': {'required': False},
+            'is_zoom_authenticated': {'required': False},
         }
 
 


### PR DESCRIPTION
Remainder of fields will be populated from zoom oauth. User creation is handled on backend side, so should not affect TranscriptionService. Closes #33 
